### PR TITLE
Avoid Conflict with HomeAssistant/OpenHAP

### DIFF
--- a/config/gateway-config.js
+++ b/config/gateway-config.js
@@ -89,7 +89,10 @@ module.exports = function (RED) {
     let socket;
     let reuse = false;
     if (!udpInputPortsInUse.hasOwnProperty(this.port)) {
-      socket = dgram.createSocket({type: 'udp4'});  // default to udp4
+      socket = dgram.createSocket({
+        type: 'udp4',
+        reuseAddr: true
+      });  // default to udp4
       socket.bind(this.port);
       udpInputPortsInUse[this.port] = socket;
     } else {


### PR DESCRIPTION
HomeAssistant has already bind 9898 port with it's xiaomi-aqara intergration, If I add a gateway config in Node Red, I'll face a EADDRINUSE error.

Add `reuseAddr: true` parameter to dgram will solve this issue.